### PR TITLE
Feature/improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # CrateDB tableau's connector.
+[![Validate and Release connector](https://github.com/crate/cratedb-tableau-connector/actions/workflows/tests_and_release.yml/badge.svg)](https://github.com/crate/cratedb-tableau-connector/actions/workflows/tests_and_release.yml)
+![GitHub Release](https://img.shields.io/github/v/release/crate/cratedb-tableau-connector)
+![Static Badge](https://img.shields.io/badge/tdvt_compatibility-81%25-brightgreen?style=flat&logo=cratedb)
+![Static Badge](https://img.shields.io/badge/CrateDB-5.10.1-brightgreen?style=flat&logo=cratedb)
 
 For simple queries and graphs, you can use the default PostgresSQL connector,
 but for more advance usage SQL compatibility issues and nuanced SQL functionalities get into play,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ we circumvent/fix those limitations with our custom connector.
 
 You will need two things:
 
-The `postgresql jdbc driver` and the `cratedb_jdbc`.
+The `postgresql jdbc driver` and the `cratedb` connector..
 
 ### Get the Postgresql jdbc driver.
 
@@ -28,10 +28,9 @@ The latest CrateDB jdbc tested driver is `cratedb-jdbc-standalone-2.7.0`
 
 Note: `postgresql-42.7.5.jar` does not seem to work.
 
-### Get the connector.
+### Get the CrateDB connector.
 
-Clone the repository `git clone https://github.com/crate/cratedb-tableau-connector.git` or manually
-download `cratedb_jdbc`.
+You can find the connector in the [release section.](https://github.com/crate/cratedb-tableau-connector/releases)
 
 Put it in: 
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,21 @@ we circumvent/fix those limitations with our custom connector.
 
 You will need two things:
 
-The `postgresql jdbc driver` and the `cratedb_tableau_connector`.
+The `postgresql jdbc driver` and the `cratedb_jdbc`.
 
 ### Get the Postgresql jdbc driver.
 
 Download the driver from [here](https://jdbc.postgresql.org/download/) and put it in:
 
-- Windows - C:\Program Files\Tableau\Drivers
-- Mac - ~/Library/Tableau/Drivers
-- Linux -  /opt/tableau/tableau_driver/jdbc 
+- Windows: `C:\Program Files\Tableau\Drivers`
+- Mac: `~/Library/Tableau/Drivers`
+- Linux: `/opt/tableau/tableau_driver/jdbc` 
 
-The latest tested one is `postgresql-42.7.3.jar`
+The latest PostgreSQL jdbc tested driver is `postgresql-42.7.4.jar`.
+
+The latest CrateDB jdbc tested driver is `cratedb-jdbc-standalone-2.7.0`
+
+Note: `postgresql-42.7.5.jar` does not seem to work.
 
 ### Get the connector.
 
@@ -33,17 +37,17 @@ Put it in:
 
 #### Tableau Desktop
 
-- Windows - C:\Users\[Windows User]\Documents\My Tableau Repository\Connectors 
-- MacOS - /Users/[user]/Documents/My Tableau Repository/Connectors
+- Windows: `C:\Users\[Windows User]\Documents\My Tableau Repository\Connectors`
+- MacOS: `/Users/[user]/Documents/My Tableau Repository/Connectors`
 
 #### Tableau Prep Builder
 
-- Windows -  C:\Users\[Windows User]\Documents\My Tableau Prep Repository\Connectors
-- MacOS - /Users//Documents/My Tableau Prep Repository/Connectors
+- Windows:  `C:\Users\[Windows User]\Documents\My Tableau Prep Repository\Connectors`
+- MacOS: `/Users//Documents/My Tableau Prep Repository/Connectors`
 
 #### Tableau Server
-- Windows - C:\Program Files\Tableau\Connectors
-- Linux - /opt/tableau/connectors
+- Windows: `C:\Program Files\Tableau\Connectors`
+- Linux: `/opt/tableau/connectors`
 
 For older versions see https://help.tableau.com/current/pro/desktop/en-us/examples_connector_sdk.htm
 
@@ -53,5 +57,5 @@ For older versions see https://help.tableau.com/current/pro/desktop/en-us/exampl
 This custom connector aims to offer the best Tableau experience possible, this is a work in progress since 
 PostgresSQL compatibility is not 100% and is bound to change over time.
 
-We test compatibility issues with Tableau's connector sdk (TDVT).
+We test compatibility issues with Tableau's connector sdk: [TDVT suite](https://tableau.github.io/connector-plugin-sdk/docs/tdvt).
 Progress is tracked in https://github.com/crate/cratedb-tableau-connector/issues/2

--- a/cratedb_jdbc/connectionResolver.tdr
+++ b/cratedb_jdbc/connectionResolver.tdr
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8' ?>
-<tdr class='cratedb_jdbc'>
+<tdr class='postgres_jdbc'>
 	<connection-resolver>
     <connection-builder>
       <script file='connectionBuilder.js'/>

--- a/cratedb_jdbc/dialect.tdd
+++ b/cratedb_jdbc/dialect.tdd
@@ -2,7 +2,7 @@
 
 <!-- See notes below for definitions that require 2020.3 or newer -->
 <dialect name='FullPostgreSQL90JDBC'
-         class='cratedb_jdbc'
+         class='postgres_jdbc'
          version='18.1'>
     <function-map>
         <function group='numeric' name='ABS' return-type='real'>
@@ -1213,6 +1213,7 @@
         <aggregation value='TRUNC_ISO_WEEK'/>
         <aggregation value='TRUNC_ISO_WEEKDAY'/>
     </supported-aggregations>
+
     <sql-format>
         <date-literal-escape value='PostgresStyle'/>
         <date-parts>
@@ -1385,5 +1386,12 @@
             <token key="V" value="TZ"/>    <!-- Time Zone: specific non-location, identical to z (PDT) -->
             <token key="VVVV" value="TZ"/> <!-- Time Zone: generic location (United States (Los Angeles)) -->
         </icu-date-token-map>
+        <supported-joins>
+            <part name='Inner'/>
+            <part name='Left'/>
+            <part name='Right'/>
+            <part name='Full'/>
+            <part name='Cross'/>
+        </supported-joins>
     </sql-format>
 </dialect>

--- a/cratedb_jdbc/manifest.xml
+++ b/cratedb_jdbc/manifest.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='cratedb_jdbc' superclass='jdbc' plugin-version='0.0.1' name='CrateDB' version='18.1' min-version-tableau='2020.4'>
+<connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.2' name='CrateDB' version='18.1' min-version-tableau='2020.4'>
   <vendor-information>
       <company name="Crate.io"/>
       <support-link url="https://github.com/crate/tableau-connector"/>
       <driver-download-link url="https://github.com/crate/tableau-connector"/>
   </vendor-information>
-  <connection-customization class="cratedb_jdbc" enabled="true" version="10.0">
+  <connection-customization class="postgres_jdbc" enabled="true" version="10.0">
     <vendor name="vendor"/>
     <driver name="driver"/>
     <customizations>

--- a/data/setup_data.py
+++ b/data/setup_data.py
@@ -44,6 +44,14 @@ if __name__ == '__main__':
         except polars.exceptions.ColumnNotFoundError:
             pass
 
+        # Set all empty strings as explicit NULLs since that's what Tableau's expects.
+        df = df.with_columns(
+            pl.when(pl.col(pl.String).str.len_chars() == 0)
+            .then(None)
+            .otherwise(pl.col(pl.String))
+            .name.keep()
+        )
+
         logging.info(f'Loading to CrateDB {file.get('name')!r}')
         df.write_database(file.get('name'),
                           connection=CRATEDB_SQLALCHEMY,

--- a/tests/config/cratedb.ini
+++ b/tests/config/cratedb.ini
@@ -4,7 +4,7 @@ LogicalQueryFormat = simple_lower
 SchemaName = doc
 CommandLineOverride = FILL_ME_WITH_PATH_OF_REPOSITORY
 [StandardTests]
-ExpressionExclusions_Standard = string.utf8, string.contains
+ExpressionExclusions_Standard = math.round.extended
 [LODTests]
 
 [UnionTest]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
* Test Tableau with latest available CrateDB version `5.10.1`, `postgres 42.7.4`
* Doc improvements
* pin jdbc to postgres

Test Count: 871 tests
        Passed tests: 705
        Failed tests: 166
        Tests run: 871
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 5.48 seconds
        Main test time: 51.67 seconds
        Total time: 57.16 seconds