### PR TITLE
Fix CI build step process outputing wrong taco name

### DIFF
--- a/.github/workflows/tests_and_release.yml
+++ b/.github/workflows/tests_and_release.yml
@@ -51,6 +51,10 @@ jobs:
           python -m connector_packager.package $GITHUB_WORKSPACE/cratedb-tableau-connector/cratedb_jdbc
           TACO_FILE_PATH=$(find "$(pwd)/packaged-connector" -name "*.taco" | head -n 1)
           
+          NEW_TACO_FILE_PATH=$(echo "$TACO_FILE_PATH" | sed 's/postgres/cratedb/')
+          mv "$TACO_FILE_PATH" "$NEW_TACO_FILE_PATH"
+          TACO_FILE_PATH=$NEW_TACO_FILE_PATH
+          
           echo Workflow: Taco file is in: $TACO_FILE_PATH
           
           if [[ "$TACO_FILE_PATH" != *"cratedb_jdbc"* ]]; then


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Title, tested in fork https://github.com/surister/cratedb-tableau-connector/releases/tag/0.0.5