### PR TITLE
Fix CI build + fix connector building.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,11 @@ jobs:
         run: |
           source ./.venv/bin/activate
           python -m connector_packager.package --validate-only $GITHUB_WORKSPACE/cratedb-tableau-connector/cratedb_jdbc
+          
+          cat packaging_logs.txt
+          
+          # If validation fails, stop the job.
+          grep 'Validation succeeded' packaging_logs.txt
 
       - name: Build connector
         if: ${{ github.event_name == 'release' }}

--- a/cratedb_jdbc/connectionFields.xml
+++ b/cratedb_jdbc/connectionFields.xml
@@ -13,4 +13,7 @@
     </boolean-options>
   </field>
 
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="ignored_field" />
+
 </connection-fields>


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The latest PR #36 broke building the connector, the CI step validating the connector correctly failed, but it failed logging the error, not actually exiting, hence the CI was green and I didn't notice until I saw the build fail while releasing. 

This PR improves the CI, the job now will fail if it finds validation issues, tested [here](https://github.com/surister/cratedb-tableau-connector/actions/runs/13720341324).
It also adds back the required field so the connector correctly builds.

Authentication behaviour still unchanged (It works), re-tested again in both local passwordless + cratedb cloud password, in the end this was all just a build CI issue.

This pr produces:

Test Count: 841 tests
        Passed tests: 809
        Failed tests: 32
        Tests run: 841
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 5.4 seconds
        Main test time: 50.89 seconds
        Total time: 56.28 seconds
