### PR TITLE
Fix VAR and VARP not being correct.

### DIFF
--- a/cratedb_jdbc/dialect.tdd
+++ b/cratedb_jdbc/dialect.tdd
@@ -726,7 +726,9 @@
             <argument type='date'/>
         </function>
         <function group='aggregate' name='STDEV' return-type='real'>
-            <formula>STDDEV(%1) * sqrt(count(%1) / (count(%1) - 1.0))</formula>
+            <formula>
+                 (CASE WHEN COUNT(%1) = 1 THEN 0.0 WHEN COUNT(%1) &gt; 0 THEN STDDEV(%1) * sqrt(count(%1) / (count(%1) - 1.0)) END)
+            </formula>
             <unagg-formula>NULL</unagg-formula>
             <argument type='real'/>
         </function>
@@ -747,13 +749,15 @@
             <argument type='int'/>
         </function>
         <function group='aggregate' name='VAR' return-type='real'>
-            <formula>VARIANCE(%1)</formula>
+            <formula>
+                 (CASE WHEN COUNT(%1) = 1 THEN 0.0 WHEN COUNT(%1) &gt; 0 THEN VARIANCE(%1) * count(%1) / (count(%1) - 1.0) END)
+            </formula>
             <unagg-formula>NULL</unagg-formula>
             <argument type='real'/>
         </function>
         <function group='aggregate' name='VARP' return-type='real'>
-            <formula>(CASE WHEN COUNT(%1) = 1 THEN 0.0 WHEN COUNT(%1) &gt; 0 THEN POWER(STDDEV(%1) * SQRT(COUNT(%1) - 1)
-                / SQRT(COUNT(%1)), 2) ELSE NULL END)
+            <formula>
+                (CASE WHEN COUNT(%1) = 1 THEN 0.0 WHEN COUNT(%1) &gt; 0 THEN VARIANCE(%1) END)
             </formula>
             <unagg-formula>(CASE WHEN %1 IS NULL THEN NULL ELSE 0.0 END)</unagg-formula>
             <argument type='real'/>


### PR DESCRIPTION
Due to not having variance population and https://github.com/crate/crate/issues/15638 we need to swap them and implement the population version by applying the bazzel correction ourselves

This PR produces:

```
Test Count: 841 tests
        Passed tests: 811
        Failed tests: 30
        Tests run: 841
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 4.21 seconds
        Main test time: 43.45 seconds
        Total time: 47.66 seconds
```
